### PR TITLE
feat: 특정 컬렉션 상세 정보 및 북마크 조회 api 구현

### DIFF
--- a/src/controllers/collectionController.ts
+++ b/src/controllers/collectionController.ts
@@ -49,3 +49,22 @@ export const getCollections = async (req: Request, res: Response, next: NextFunc
     next(error);
   }
 };
+
+export const getCollectionDetail = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    if (!req.user) {
+      throw new AppError('AUTH_001', '인증되지 않은 사용자입니다.');
+    }
+    const userId = req.user.userId;
+    const collectionId = parseInt(req.params.collectionId, 10);
+
+    if (isNaN(collectionId)) {
+      throw new AppError('COLLECTION_004', '유효하지 않은 컬렉션 ID입니다.');
+    }
+
+    const collectionDetail = await collectionService.getCollectionDetailById(collectionId, userId);
+    sendSuccess(res, collectionDetail);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/dtos/collectionDto.ts
+++ b/src/dtos/collectionDto.ts
@@ -16,3 +16,24 @@ export interface CreateCollectionDto {
   description?: string;
   visibility?: CollectionVisibility;
 }
+
+export interface BookmarkInCollectionDto {
+  bookmarkId: number;
+  videoTitle: string;
+  videoThumbnail: string;
+  roomTitle: string;
+  message: string;
+  createdAt: Date;
+}
+
+export interface GetCollectionDetailDto {
+  collectionId: number;
+  title: string;
+  description: string | null;
+  bookmarkCount: number;
+  visibility: CollectionVisibility;
+  coverImage: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  bookmarks: BookmarkInCollectionDto[];
+}

--- a/src/routes/collectionRoutes.ts
+++ b/src/routes/collectionRoutes.ts
@@ -71,4 +71,33 @@ router.post('/', requireAuth, collectionController.createCollection);
  */
 router.get('/', requireAuth, collectionController.getCollections);
 
+/**
+ * @swagger
+ * /api/collections/{collectionId}:
+ *   get:
+ *     summary: 특정 컬렉션의 상세 정보 및 북마크 조회
+ *     tags: [Collections]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: collectionId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: 컬렉션 ID
+ *     responses:
+ *       200:
+ *         description: 컬렉션 상세 정보 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/GetCollectionDetailDto'
+ *       401:
+ *         description: 인증되지 않은 사용자 또는 권한 없음
+ *       404:
+ *         description: 컬렉션을 찾을 수 없음
+ */
+router.get('/:collectionId', requireAuth, collectionController.getCollectionDetail);
+
 export default router;

--- a/src/services/collectionService.ts
+++ b/src/services/collectionService.ts
@@ -1,5 +1,9 @@
 import { PrismaClient } from '@prisma/client';
-import { CreateCollectionDto, GetCollectionDto } from '../dtos/collectionDto.js';
+import {
+  CreateCollectionDto,
+  GetCollectionDto,
+  GetCollectionDetailDto,
+} from '../dtos/collectionDto.js';
 import AppError from '../middleware/errors/AppError.js';
 
 const prisma = new PrismaClient();
@@ -44,4 +48,51 @@ export const getCollectionsByUserId = async (userId: number): Promise<GetCollect
     createdAt: collection.createdAt,
     updatedAt: collection.updatedAt,
   }));
+};
+
+export const getCollectionDetailById = async (
+  collectionId: number,
+  userId: number,
+): Promise<GetCollectionDetailDto> => {
+  const collection = await prisma.collection.findUnique({
+    where: { collectionId },
+    include: {
+      bookmarks: {
+        include: {
+          room: {
+            include: {
+              video: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!collection) {
+    throw new AppError('COLLECTION_001', '컬렉션을 찾을 수 없습니다.');
+  }
+
+  if (collection.visibility === 'private' && collection.userId !== userId) {
+    throw new AppError('COLLECTION_003', '비공개 컬렉션에 접근할 권한이 없습니다.');
+  }
+
+  return {
+    collectionId: collection.collectionId,
+    title: collection.title,
+    description: collection.description,
+    bookmarkCount: collection.bookmarkCount,
+    visibility: collection.visibility,
+    coverImage: collection.coverImage,
+    createdAt: collection.createdAt,
+    updatedAt: collection.updatedAt,
+    bookmarks: collection.bookmarks.map(bookmark => ({
+      bookmarkId: bookmark.bookmarkId,
+      videoTitle: bookmark.room.video.title,
+      videoThumbnail: bookmark.room.video.thumbnail || '',
+      roomTitle: bookmark.room.roomName,
+      message: `${String(Math.floor(bookmark.timeline! / 60)).padStart(2, '0')}:${String(bookmark.timeline! % 60).padStart(2, '0')} ${bookmark.content}`,
+      createdAt: bookmark.createdAt,
+    })),
+  };
 };

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -52,6 +52,37 @@ const options: swaggerJsdoc.Options = {
             updatedAt: { type: 'string', format: 'date-time' },
           },
         },
+        GetCollectionDetailDto: {
+          type: 'object',
+          properties: {
+            collectionId: { type: 'integer', example: 123 },
+            title: { type: 'string', example: '컬렉션 제목' },
+            description: { type: 'string', example: '컬렉션 소개' },
+            bookmarkCount: { type: 'integer', example: 5 },
+            visibility: {
+              type: 'string',
+              enum: ['public', 'friends', 'private'],
+              example: 'private',
+            },
+            coverImage: { type: 'string', nullable: true, example: '커버이미지URL' },
+            createdAt: { type: 'string', format: 'date-time' },
+            updatedAt: { type: 'string', format: 'date-time' },
+            bookmarks: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  bookmarkId: { type: 'integer', example: 456 },
+                  videoTitle: { type: 'string', example: '비디오 제목' },
+                  videoThumbnail: { type: 'string', example: '비디오 썸네일 URL' },
+                  roomTitle: { type: 'string', example: '방 제목' },
+                  message: { type: 'string', example: '북마크 메시지' },
+                  createdAt: { type: 'string', format: 'date-time' },
+                },
+              },
+            },
+          },
+        },
         CreateCollectionDto: {
           type: 'object',
           properties: {


### PR DESCRIPTION
## 🚩 관련 이슈
<!-- PR과 관련된 이슈 번호를 작성해주세요. ex) #이슈 번호 -->
- close #105 


## 📋 작업 내용
<!-- 해당 이슈와 이번 PR에서 작업한 내용에 대해서 간략하게 작성해주세요. -->
- 특정 컬렉션의 상세 정보 및 북마크를 조회할 수 있는 기능을 추가했습니다.
- 컬렉션 공개 범위에 따라 조회되도록 했습니다. ex) private일 때 본인만 조회 가능, friends일 때 친구인 사용자까지만 조회 가능, public일 때 모든 사용자 조회 가능


## ✅ 테스트 방법
<!-- 리뷰어가 변경 사항을 테스트하는 방법을 작성해주세요.(선택) ex) Postman으로 /users POST 요청 후 201 응답 확인 -->
- http://localhost:3000/api/collections/{collectionId} 로 테스트 가능합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 특정 컬렉션의 상세 정보와 해당 컬렉션에 포함된 북마크 목록을 조회할 수 있는 API가 추가되었습니다.

* **문서화**
  * 컬렉션 상세 조회 엔드포인트 및 응답 구조가 Swagger 문서에 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->